### PR TITLE
fix typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ mv linux-rpi-3.12.y linux
 
 ln -s /usr/src/linux /lib/modules/$(uname -r)/build
 ln -s /usr/src/linux /lib/modules/$(uname -r)/source 
-cd /src/linux
+cd /usr/src/linux
 
 make mrproper
 


### PR DESCRIPTION
The "example for raspberry pi" section in the readme said `/src/linux` where it should have said `/usr/src/linux`
