### PR TITLE
Update gspca.c

### DIFF
--- a/gspca.c
+++ b/gspca.c
@@ -2067,7 +2067,11 @@ int gspca_dev_probe2(struct usb_interface *intf,
 	gspca_dev->vdev = gspca_template;
 	gspca_dev->vdev.v4l2_dev = &gspca_dev->v4l2_dev;
 	video_set_drvdata(&gspca_dev->vdev, gspca_dev);
+#ifdef V4L2_FL_USE_FH_PRIO
 	set_bit(V4L2_FL_USE_FH_PRIO, &gspca_dev->vdev.flags);
+#else
+	set_bit(V4L2_FL_USES_V4L2_FH, &gspca_dev->vdev.flags);
+#endif
 	gspca_dev->module = module;
 	gspca_dev->present = 1;
 


### PR DESCRIPTION
V4L2_FL_USE_FH_PRIO has been removed from v4l2-dev.h, as far as I can work out V4L2_FL_USES_V4L2_FH should be used instead

- flags: optional. Set to V4L2_FL_USE_FH_PRIO if you want to let the framework
  handle the VIDIOC_G/S_PRIORITY ioctls. This requires that you use struct
  v4l2_fh. Eventually this flag will disappear once all drivers use the core
  priority handling. But for now it has to be set explicitly.


This way at least it builds when missing, however I'm not sure what's going on here and there may be other changes needed to deal with this problem.